### PR TITLE
workaround for slow foldexpr

### DIFF
--- a/ftplugin/lua.vim
+++ b/ftplugin/lua.vim
@@ -1,13 +1,6 @@
 setlocal omnifunc=lua#complete
 
-if exists('g:spacevim_lua_foldmethod')
-  if g:spacevim_lua_foldmethod ==# 'expr'
-    setlocal foldmethod=expr
-    setlocal foldexpr=lua#fold#foldlevel(v:lnum)
-  else
-    let &l:foldmethod = g:spacevim_lua_foldmethod
-  endif
-else
-  setlocal foldmethod=manual
+if &l:foldmethod ==# 'expr'
+  setlocal foldexpr=lua#fold#foldlevel(v:lnum)
 endif
 setlocal nofoldenable

--- a/ftplugin/lua.vim
+++ b/ftplugin/lua.vim
@@ -1,4 +1,13 @@
 setlocal omnifunc=lua#complete
-setlocal foldexpr=lua#fold#foldlevel(v:lnum)
-setlocal foldmethod=expr
+
+if exists('g:spacevim_lua_foldmethod')
+  if g:spacevim_lua_foldmethod ==# 'expr'
+    setlocal foldmethod=expr
+    setlocal foldexpr=lua#fold#foldlevel(v:lnum)
+  else
+    let &l:foldmethod = g:spacevim_lua_foldmethod
+  endif
+else
+  setlocal foldmethod=manual
+endif
 setlocal nofoldenable


### PR DESCRIPTION
- default foldmethod to manual until foldexpr slowness fixed
- can still use any foldmethod (incl. expr) by defining g:spacevim_lua_foldmethod